### PR TITLE
This update resolves a playback bug where pressing play again when a playlist is playing causes playback to stop and the playlist to begin scrolling for a short time before scrolling stops and playback starts on a new file.

### DIFF
--- a/DigitalAudioExperiment/Logic/AudioPlayerBase.cs
+++ b/DigitalAudioExperiment/Logic/AudioPlayerBase.cs
@@ -360,6 +360,9 @@ namespace DigitalAudioExperiment.Logic
 
         public abstract string GetMetadata();
 
+        public bool IsDisposed()
+            => _isDisposed;
+
         #endregion
 
         #region Cleanup and Dispose

--- a/DigitalAudioExperiment/Logic/AudioPlayerPcm.cs
+++ b/DigitalAudioExperiment/Logic/AudioPlayerPcm.cs
@@ -51,6 +51,7 @@ namespace DigitalAudioExperiment.Logic
                 MessageBox.Show(exception.Message);
 
                 _isPlaying = false;
+                Dispose();
             }
         }
 

--- a/DigitalAudioExperiment/Logic/IAudioPlayer.cs
+++ b/DigitalAudioExperiment/Logic/IAudioPlayer.cs
@@ -78,6 +78,8 @@ namespace DigitalAudioExperiment.Logic
 
         string GetMetadata();
 
+        bool IsDisposed();
+
         #endregion
 
         #region Cleanup and Dispose

--- a/DigitalAudioExperiment/ViewModel/ReceiverViewModel.cs
+++ b/DigitalAudioExperiment/ViewModel/ReceiverViewModel.cs
@@ -408,7 +408,8 @@ namespace DigitalAudioExperiment.ViewModel
             }
 
             if (_player != null
-                && !_player.IsStopped())
+                && !_player.IsStopped()
+                && _player.IsDisposed())
             {
                 _player.Stop();
                 _player.Dispose();


### PR DESCRIPTION
This update resolves a playback bug where pressing play again when a playlist is playing causes playback to stop and the playlist to begin scrolling for a short time before scrolling stops and playback starts on a new file.